### PR TITLE
index: fix empty http conf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const scribe = (config) => {
   const messageMasker = createMessageMasker(sensitive)
   const messageBuilder = createMessageBuilder(messageMasker, service)
   const logger = createLogger(vendorLogger, messageBuilder)
-  const httpLogger = createHttpLogger(vendorLogger, messageBuilder, httpConf)
+  const httpLogger = createHttpLogger(vendorLogger, messageBuilder, httpConf || {})
   return { logger, httpLogger }
 }
 


### PR DESCRIPTION
When user don't pass a http conf we set its value to {}